### PR TITLE
Feature/CON-2158/CSP Refactor

### DIFF
--- a/pwa/gatsby-config.js
+++ b/pwa/gatsby-config.js
@@ -13,9 +13,9 @@ module.exports = {
         mergeStyleHashes: true,
         directives: {
           "script-src":
-            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/",
+            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/ 'unsafe-eval'",
           "style-src":
-            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/",
+            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/ 'sha256-cLHlYu9WwZQgD1K6YlWPqFYXJEuD9YpxdlDktBDedco='",
           "img-src": "'self' https://demodam.nl/ data:",
           "font-src":
             "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/",


### PR DESCRIPTION
In deze pull request worden de Content Security Policy headers aangepast (via de `gatsby-plugin-csp`). 

- De `script-src` wordt nu succesvol ingeladen met een `unsafe-eval` (let op: dit mag niet gebeuren op de `skeleton-app` doordat daar DigID integraties zijn);
- De `style-src` wordt nu succesvol ingeladen met een `sha256` hash.