### PR TITLE
feature/GW-32/language-dropdown

### DIFF
--- a/pwa/src/components/translations/translationForm.tsx
+++ b/pwa/src/components/translations/translationForm.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import {
   GenericInputComponent,
   Card,
-  Alert
+  Alert,
+  SelectInputComponent
 }
   from "@conductionnl/nl-design-system/lib";
 import {Link} from "gatsby";
@@ -118,12 +119,15 @@ export const TranslationForm: React.FC<TranslationFormProps> = ({id}) => {
                         </div>
                         <div className="col-6">
                           <div className="form-group">
-                            <GenericInputComponent
-                              type={"text"}
+                            <SelectInputComponent
+                              options={[
+                                {name: "Nederlands (NL)", value: 'nl_NL'},
+                                {name: "English (EN)", value: "en_EN"},
+                              ]}
                               name={"language"}
                               id={"languageInput"}
-                              data={translation && translation.language && translation.language}
-                              nameOverride={"Language"}/>
+                              nameOverride={"Language"}
+                              data={translation?.language}/>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
This pull request includes:

- Refactor of the language field within the `TranslationForm` form to a `SelectInputComponent`;

**Note: ** @bbrands02 the actual adding of TableNameTables doesn't seem to work. Is this something you're still working on? (This code did not break it).