### PR TITLE
Feature/gw 20/expired jwt redirect

### DIFF
--- a/pwa/gatsby-browser.js
+++ b/pwa/gatsby-browser.js
@@ -3,6 +3,17 @@ import "@utrecht/design-tokens/dist/theme/index.css";
 import { UrlContextWrapper } from "./src/context/urlContext";
 import { UserContextWrapper } from "./src/context/userContext";
 import "./src/styles/main.css";
+import { isLoggedIn, logout, validateSession } from "./src/services/auth";
+
+export const onRouteUpdate = () => {
+  if (!isLoggedIn()) {
+    return;
+  }
+
+  if (!validateSession) {
+    logout();
+  }
+};
 
 export const wrapRootElement = ({ element }) => (
   <UserContextWrapper>

--- a/pwa/src/apiService/apiService.ts
+++ b/pwa/src/apiService/apiService.ts
@@ -151,7 +151,7 @@ export const Send = (
   if (!validateSession()) {
     logout();
 
-    return Promise.resolve({});
+    return Promise.resolve({ data: [] });
   }
 
   switch (method) {

--- a/pwa/src/apiService/apiService.ts
+++ b/pwa/src/apiService/apiService.ts
@@ -141,7 +141,7 @@ export default class APIService {
 }
 
 export const Send = (
-  _instance: AxiosInstance,
+  instance: AxiosInstance,
   method: "GET" | "POST" | "PUT" | "DELETE",
   endpoint: string,
   payload?: JSON,
@@ -156,12 +156,12 @@ export const Send = (
 
   switch (method) {
     case "GET":
-      return _instance.get(endpoint);
+      return instance.get(endpoint);
     case "POST":
-      return _instance.post(endpoint, _payload);
+      return instance.post(endpoint, _payload);
     case "PUT":
-      return _instance.put(endpoint, _payload);
+      return instance.put(endpoint, _payload);
     case "DELETE":
-      return _instance.delete(endpoint);
+      return instance.delete(endpoint);
   }
 };

--- a/pwa/src/apiService/resources/ObjectEntity.ts
+++ b/pwa/src/apiService/resources/ObjectEntity.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class ObjectEntity {
@@ -8,26 +9,26 @@ export default class ObjectEntity {
   }
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/object_entities/${id}`);
+    return Send(this._instance, "GET", `/object_entities/${id}`);
   };
 
   public sync = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/object_entities/${id}/sync`);
+    return Send(this._instance, "GET", `/object_entities/${id}/sync`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/object_entities", JSON.stringify(data));
+    return Send(this._instance, "POST", "/object_entities", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/object_entities/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/object_entities/${id}`, data);
   };
 
   public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/object_entities?entity.id=${entityId}`);
+    return Send(this._instance, "GET", `/object_entities?entity.id=${entityId}`);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/object_entities/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/object_entities/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/ObjectEntity.ts
+++ b/pwa/src/apiService/resources/ObjectEntity.ts
@@ -8,27 +8,27 @@ export default class ObjectEntity {
     this._instance = _instance;
   }
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/object_entities/${id}`);
   };
 
-  public sync = (id: string): Promise<AxiosResponse> => {
+  public sync = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/object_entities/${id}/sync`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/object_entities", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/object_entities/${id}`, data);
   };
 
-  public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
+  public getAllFromEntity = (entityId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/object_entities?entity.id=${entityId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/object_entities/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/apiCalls.ts
+++ b/pwa/src/apiService/resources/apiCalls.ts
@@ -8,11 +8,11 @@ export default class FormIO {
     this._instance = _instance;
   }
 
-  public createObject = (endpoint: string, data: any): Promise<AxiosResponse> => {
+  public createObject = (endpoint: string, data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", `/${endpoint}`, data);
   };
 
-  public updateObject = (endpoint: string, id: string, data: any): Promise<AxiosResponse> => {
+  public updateObject = (endpoint: string, id: string, data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/${endpoint}/${id}`, data);
   };
 }

--- a/pwa/src/apiService/resources/apiCalls.ts
+++ b/pwa/src/apiService/resources/apiCalls.ts
@@ -1,17 +1,18 @@
-import { AxiosInstance, AxiosResponse } from "axios"
+import { Send } from "../apiService";
+import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class FormIO {
-  private _instance: AxiosInstance
+  private _instance: AxiosInstance;
 
-  constructor (_instance: AxiosInstance) {
-    this._instance = _instance
+  constructor(_instance: AxiosInstance) {
+    this._instance = _instance;
   }
-  
+
   public createObject = (endpoint: string, data: any): Promise<AxiosResponse> => {
-    return this._instance.post(`/${endpoint}`, JSON.stringify(data));
-  }
+    return Send(this._instance, "POST", `/${endpoint}`, data);
+  };
 
   public updateObject = (endpoint: string, id: string, data: any): Promise<AxiosResponse> => {
-    return this._instance.put(`/${endpoint}/${id}`, JSON.stringify(data));
-  }
+    return Send(this._instance, "PUT", `/${endpoint}/${id}`, data);
+  };
 }

--- a/pwa/src/apiService/resources/application.ts
+++ b/pwa/src/apiService/resources/application.ts
@@ -8,23 +8,23 @@ export default class Application {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
+  public getAll = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/applications");
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/applications/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/applications", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/applications/${id}`, data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/applications/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/application.ts
+++ b/pwa/src/apiService/resources/application.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Application {
@@ -8,22 +9,22 @@ export default class Application {
   }
 
   public getAll = (): Promise<AxiosResponse> => {
-    return this._instance.get("/applications");
+    return Send(this._instance, "GET", "/applications");
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/applications/${id}`);
+    return Send(this._instance, "GET", `/applications/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/applications", JSON.stringify(data));
+    return Send(this._instance, "POST", "/applications", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/applications/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/applications/${id}`, data);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/applications/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/applications/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/attribute.ts
+++ b/pwa/src/apiService/resources/attribute.ts
@@ -8,27 +8,27 @@ export default class Entity {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
+  public getAll = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/attributes");
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/attributes/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/attributes", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/attributes/${id}`, data);
   };
 
-  public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
+  public getAllFromEntity = (entityId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/attributes?entity.id=${entityId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/attributes/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/attribute.ts
+++ b/pwa/src/apiService/resources/attribute.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Entity {
@@ -8,26 +9,26 @@ export default class Entity {
   }
 
   public getAll = (): Promise<AxiosResponse> => {
-    return this._instance.get("/attributes");
+    return Send(this._instance, "GET", "/attributes");
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/attributes/${id}`);
+    return Send(this._instance, "GET", `/attributes/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/attributes", JSON.stringify(data));
+    return Send(this._instance, "POST", "/attributes", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/attributes/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/attributes/${id}`, data);
   };
 
   public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/attributes?entity.id=${entityId}`);
+    return Send(this._instance, "GET", `/attributes?entity.id=${entityId}`);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/attributes/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/attributes/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Endpoint {
@@ -8,22 +9,22 @@ export default class Endpoint {
   }
 
   public getAll = (): Promise<AxiosResponse> => {
-    return this._instance.get("/endpoints");
+    return Send(this._instance, "GET", "/endpoints");
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/endpoints/${id}`);
+    return Send(this._instance, "GET", `/endpoints/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/endpoints", JSON.stringify(data));
+    return Send(this._instance, "POST", "/endpoints", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/endpoints/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/endpoints/${id}`, data);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/endpoints/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/endpoints/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -8,23 +8,23 @@ export default class Endpoint {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
+  public getAll = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/endpoints");
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/endpoints/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/endpoints", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/endpoints/${id}`, data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/endpoints/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/entity.ts
+++ b/pwa/src/apiService/resources/entity.ts
@@ -8,23 +8,23 @@ export default class Entity {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
+  public getAll = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/entities");
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/entities/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/entities", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/entities/${id}`, data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/entities/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/entity.ts
+++ b/pwa/src/apiService/resources/entity.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Entity {
@@ -8,22 +9,22 @@ export default class Entity {
   }
 
   public getAll = (): Promise<AxiosResponse> => {
-    return this._instance.get("/entities");
+    return Send(this._instance, "GET", "/entities");
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/entities/${id}`);
+    return Send(this._instance, "GET", `/entities/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/entities", JSON.stringify(data));
+    return Send(this._instance, "POST", "/entities", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/entities/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/entities/${id}`, data);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/entities/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/entities/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/formIO.ts
+++ b/pwa/src/apiService/resources/formIO.ts
@@ -8,7 +8,7 @@ export default class FormIO {
     this._instance = _instance;
   }
 
-  public getSchema = (endpoint: string): Promise<AxiosResponse> => {
+  public getSchema = (endpoint: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/${endpoint}`);
   };
 }

--- a/pwa/src/apiService/resources/formIO.ts
+++ b/pwa/src/apiService/resources/formIO.ts
@@ -1,13 +1,14 @@
-import { AxiosInstance, AxiosResponse } from "axios"
+import { Send } from "../apiService";
+import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class FormIO {
-  private _instance: AxiosInstance
+  private _instance: AxiosInstance;
 
-  constructor (_instance: AxiosInstance) {
-    this._instance = _instance
+  constructor(_instance: AxiosInstance) {
+    this._instance = _instance;
   }
 
   public getSchema = (endpoint: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/${endpoint}`);
-  }
+    return Send(this._instance, "GET", `/${endpoint}`);
+  };
 }

--- a/pwa/src/apiService/resources/handler.ts
+++ b/pwa/src/apiService/resources/handler.ts
@@ -8,23 +8,23 @@ export default class Handler {
     this._instance = _instance;
   }
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/handlers/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/handlers", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/handlers/${id}`, data);
   };
 
-  public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse> => {
+  public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/handlers?endpoint.id=${endpointId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/handlers/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/handler.ts
+++ b/pwa/src/apiService/resources/handler.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Handler {
@@ -8,23 +9,22 @@ export default class Handler {
   }
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/handlers/${id}`);
+    return Send(this._instance, "GET", `/handlers/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/handlers", JSON.stringify(data));
+    return Send(this._instance, "POST", "/handlers", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/handlers/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/handlers/${id}`, data);
   };
 
   public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse> => {
-
-    return this._instance.get(`/handlers?endpoint.id=${endpointId}`);
+    return Send(this._instance, "GET", `/handlers?endpoint.id=${endpointId}`);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/handlers/${id}`);
+    return Send(this._instance, "DELETE", `/handlers/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/log.ts
+++ b/pwa/src/apiService/resources/log.ts
@@ -8,31 +8,31 @@ export default class Log {
     this._instance = _instance;
   }
 
-  public getAllIncoming = (): Promise<AxiosResponse> => {
+  public getAllIncoming = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/logs?type=in");
   };
 
-  public getAllFromSession = (sessionId: string): Promise<AxiosResponse> => {
+  public getAllFromSession = (sessionId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?session=${sessionId}`);
   };
 
-  public getAllFromCall = (callId: string): Promise<AxiosResponse> => {
+  public getAllFromCall = (callId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?callId=${callId}`);
   };
 
-  public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
+  public getAllFromEntity = (entityId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?entity.id=${entityId}`);
   };
 
-  public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse> => {
+  public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?endpoint.id=${endpointId}`);
   };
 
-  public getAllFromSource = (sourceId: string): Promise<AxiosResponse> => {
+  public getAllFromSource = (sourceId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?source.id=${sourceId}`);
   };
 
-  public getAllOutgoingFromCallId = (callId: string): Promise<AxiosResponse> => {
+  public getAllOutgoingFromCallId = (callId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/logs?type=out&callId=${callId}`);
   };
 }

--- a/pwa/src/apiService/resources/log.ts
+++ b/pwa/src/apiService/resources/log.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Log {
@@ -8,30 +9,30 @@ export default class Log {
   }
 
   public getAllIncoming = (): Promise<AxiosResponse> => {
-    return this._instance.get("/logs?type=in");
+    return Send(this._instance, "GET", "/logs?type=in");
   };
 
   public getAllFromSession = (sessionId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/logs?session=${sessionId}`);
+    return Send(this._instance, "GET", `/logs?session=${sessionId}`);
   };
 
   public getAllFromCall = (callId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/logs?callId=${callId}`);
+    return Send(this._instance, "GET", `/logs?callId=${callId}`);
   };
 
   public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
-    return this._instance.get("/logs?entity.id=" + entityId);
+    return Send(this._instance, "GET", `/logs?entity.id=${entityId}`);
   };
 
   public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse> => {
-    return this._instance.get("/logs?endpoint.id=" + endpointId);
+    return Send(this._instance, "GET", `/logs?endpoint.id=${endpointId}`);
   };
 
   public getAllFromSource = (sourceId: string): Promise<AxiosResponse> => {
-    return this._instance.get("/logs?source.id=" + sourceId);
+    return Send(this._instance, "GET", `/logs?source.id=${sourceId}`);
   };
 
   public getAllOutgoingFromCallId = (callId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/logs?type=out&callId=${callId}`);
+    return Send(this._instance, "GET", `/logs?type=out&callId=${callId}`);
   };
 }

--- a/pwa/src/apiService/resources/source.ts
+++ b/pwa/src/apiService/resources/source.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Source {
@@ -8,22 +9,22 @@ export default class Source {
   }
 
   public getAll = (): Promise<AxiosResponse> => {
-    return this._instance.get("/gateways");
+    return Send(this._instance, "GET", "/gateways");
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/gateways/${id}`);
+    return Send(this._instance, "GET", `/gateways/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/gateways", JSON.stringify(data));
+    return Send(this._instance, "POST", "/gateways", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/gateways/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/gateways/${id}`, data);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/gateways/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/gateways/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/source.ts
+++ b/pwa/src/apiService/resources/source.ts
@@ -1,5 +1,5 @@
 import { Send } from "../apiService";
-import { AxiosInstance, AxiosResponse } from "axios";
+import { AxiosInstance, AxiosResponse | {} } from "axios";
 
 export default class Source {
   private _instance: AxiosInstance;
@@ -8,23 +8,23 @@ export default class Source {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
+  public getAll = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/gateways");
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/gateways/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/gateways", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/gateways/${id}`, data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/gateways/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/source.ts
+++ b/pwa/src/apiService/resources/source.ts
@@ -1,5 +1,5 @@
 import { Send } from "../apiService";
-import { AxiosInstance, AxiosResponse | {} } from "axios";
+import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Source {
   private _instance: AxiosInstance;

--- a/pwa/src/apiService/resources/subscriber.ts
+++ b/pwa/src/apiService/resources/subscriber.ts
@@ -8,23 +8,23 @@ export default class Subscriber {
     this._instance = _instance;
   }
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/subscribers/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/subscribers", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/subscribers/${id}`, data);
   };
 
-  public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
+  public getAllFromEntity = (entityId: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/subscribers?entity.id=${entityId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/subscribers/${id}`);
   };
 }

--- a/pwa/src/apiService/resources/subscriber.ts
+++ b/pwa/src/apiService/resources/subscriber.ts
@@ -1,3 +1,4 @@
+import { Send } from "../apiService";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 export default class Subscriber {
@@ -8,22 +9,22 @@ export default class Subscriber {
   }
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/subscribers/${id}`);
+    return Send(this._instance, "GET", `/subscribers/${id}`);
   };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post("/subscribers", JSON.stringify(data));
+    return Send(this._instance, "POST", "/subscribers", data);
   };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/subscribers/${id}`, JSON.stringify(data));
+    return Send(this._instance, "PUT", `/subscribers/${id}`, data);
   };
 
   public getAllFromEntity = (entityId: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/subscribers?entity.id=${entityId}`);
+    return Send(this._instance, "GET", `/subscribers?entity.id=${entityId}`);
   };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/subscribers/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/subscribers/${id}`);
+  };
 }

--- a/pwa/src/apiService/resources/translation.ts
+++ b/pwa/src/apiService/resources/translation.ts
@@ -1,33 +1,34 @@
-import { AxiosInstance, AxiosResponse } from "axios"
+import { AxiosInstance, AxiosResponse } from "axios";
+import { Send } from "../apiService";
 
 export default class Translation {
-  private _instance: AxiosInstance
+  private _instance: AxiosInstance;
 
-  constructor (_instance: AxiosInstance) {
-    this._instance = _instance
+  constructor(_instance: AxiosInstance) {
+    this._instance = _instance;
   }
 
   public getAllFrom = (tableName: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/translations?translationTable=${tableName}`)
-  }
+    return Send(this._instance, "GET", `/translations?translationTable=${tableName}`);
+  };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
-    return this._instance.get(`/translations/${id}`)
-  }
+    return Send(this._instance, "GET", `/translations/${id}`);
+  };
 
   public create = (data: any): Promise<AxiosResponse> => {
-    return this._instance.post('/translations', JSON.stringify(data))
-  }
+    return Send(this._instance, "POST", "/translations", data);
+  };
 
   public update = (data: any, id: string): Promise<AxiosResponse> => {
-    return this._instance.put(`/translations/${id}`, JSON.stringify(data))
-  }
+    return Send(this._instance, "PUT", `/translations/${id}`, data);
+  };
 
   public delete = (id: string): Promise<AxiosResponse> => {
-    return this._instance.delete(`/translations/${id}`)
-  }
+    return Send(this._instance, "DELETE", `/translations/${id}`);
+  };
 
   public getTableNames = (): Promise<AxiosResponse> => {
-    return this._instance.get("/table_names")
-  }
+    return Send(this._instance, "GET", "/table_names");
+  };
 }

--- a/pwa/src/apiService/resources/translation.ts
+++ b/pwa/src/apiService/resources/translation.ts
@@ -8,27 +8,27 @@ export default class Translation {
     this._instance = _instance;
   }
 
-  public getAllFrom = (tableName: string): Promise<AxiosResponse> => {
+  public getAllFrom = (tableName: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/translations?translationTable=${tableName}`);
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
+  public getOne = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", `/translations/${id}`);
   };
 
-  public create = (data: any): Promise<AxiosResponse> => {
+  public create = (data: any): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "POST", "/translations", data);
   };
 
-  public update = (data: any, id: string): Promise<AxiosResponse> => {
+  public update = (data: any, id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "PUT", `/translations/${id}`, data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
+  public delete = (id: string): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "DELETE", `/translations/${id}`);
   };
 
-  public getTableNames = (): Promise<AxiosResponse> => {
+  public getTableNames = (): Promise<AxiosResponse | {}> => {
     return Send(this._instance, "GET", "/table_names");
   };
 }

--- a/pwa/src/components/common/layout.tsx
+++ b/pwa/src/components/common/layout.tsx
@@ -31,7 +31,6 @@ export default function Layout({ children, pageContext }) {
     }
 
     const jwt = sessionStorage.getItem("jwt");
-    !validateSession(jwt) && logout()
     !API && jwt && setAPI(new APIService(jwt));
   }, [API, isLoggedIn()]);
 
@@ -48,7 +47,7 @@ export default function Layout({ children, pageContext }) {
               <MainMenu />
               <div className="utrecht-page__content">
                 <header className="utrecht-page-header">
-                  <Header { ...{ pageContext } } />
+                  <Header {...{ pageContext }} />
                 </header>
                 <div className="container py-4">{children}</div>
               </div>

--- a/pwa/src/pages/login/index.tsx
+++ b/pwa/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import "./login.css";
 import APIService from "../../apiService/apiService";
-import { setUser } from "../../services/auth";
+import { isLoggedIn, setUser } from "../../services/auth";
 import { navigate } from "gatsby-link";
 import Footer from "../../components/footer/footer";
 import Particles from "react-tsparticles";
@@ -13,45 +13,51 @@ const Login: React.FC = () => {
   const [loading, setLoading] = React.useState<boolean>(false);
   const API: APIService = new APIService("");
 
-  const handleLogin = (): void => {
-    setLoading(true)
+  React.useEffect(() => {
+    isLoggedIn() && navigate("/");
+  }, [API]);
 
-    const body = {...{username, password}}
+  const handleLogin = (): void => {
+    setLoading(true);
+
+    const body = { ...{ username, password } };
 
     API.Login.login(body)
       .then((res) => {
-        const user = { username: res.data.username }
+        const user = { username: res.data.username };
 
-        setUser(user)
+        setUser(user);
         sessionStorage.setItem("jwt", res.data.jwtToken);
         sessionStorage.setItem("user", JSON.stringify(user));
 
-        navigate('/')
+        navigate("/");
       })
       .catch((err) => {
-        setError(err.response.data.message)
+        setError(err.response.data.message);
       })
-      .finally(() => { setLoading(false) })
-  }
+      .finally(() => {
+        setLoading(false);
+      });
+  };
 
   return (
     <div className="login">
-      <Particles options={
-        {
+      <Particles
+        options={{
           fpsLimit: 60,
           particles: {
             color: {
-              value: "#ffffff"
+              value: "#ffffff",
             },
             links: {
               color: "#ffffff",
               distance: 150,
               enable: true,
               opacity: 0.5,
-              width: 1
+              width: 1,
             },
             collisions: {
-              enable: true
+              enable: true,
             },
             move: {
               direction: "none",
@@ -59,29 +65,29 @@ const Login: React.FC = () => {
               outMode: "bounce",
               random: false,
               speed: 2,
-              straight: false
+              straight: false,
             },
             number: {
               density: {
                 enable: true,
-                area: 800
+                area: 800,
               },
-              value: 80
+              value: 80,
             },
             opacity: {
-              value: 0.5
+              value: 0.5,
             },
             shape: {
-              type: "circle"
+              type: "circle",
             },
             size: {
               random: true,
-              value: 5
-            }
+              value: 5,
+            },
           },
-          detectRetina: true
-        }
-      } />
+          detectRetina: true,
+        }}
+      />
 
       <div className="login-container">
         <h1>Welcome to Conductor!</h1>
@@ -94,18 +100,20 @@ const Login: React.FC = () => {
             placeholder="Username"
             onChange={(e) => setUsername(e.target.value)}
             disabled={loading}
-            required />
+            required
+          />
 
           <input
             type="password"
             placeholder="Password"
             onChange={(e) => setPassword(e.target.value)}
             disabled={loading}
-            required />
+            required
+          />
 
           {error && <span className="login-form-error">{error}</span>}
 
-          <button onClick={handleLogin} disabled={loading || (!username || !password)}>
+          <button onClick={handleLogin} disabled={loading || !username || !password}>
             {!loading ? "Login" : "Loading..."}
           </button>
         </form>

--- a/pwa/src/services/auth.tsx
+++ b/pwa/src/services/auth.tsx
@@ -4,12 +4,9 @@ import jwtDecode, { JwtPayload } from "jwt-decode";
 export const isBrowser = () => typeof window !== "undefined";
 
 export const getUser = () =>
-  isBrowser() && window.sessionStorage.getItem("user")
-    ? JSON.parse(window.sessionStorage.getItem("user"))
-    : {};
+  isBrowser() && window.sessionStorage.getItem("user") ? JSON.parse(window.sessionStorage.getItem("user")) : {};
 
-export const setUser = (user) =>
-  window.sessionStorage.setItem("user", JSON.stringify(user));
+export const setUser = (user) => window.sessionStorage.setItem("user", JSON.stringify(user));
 
 export const handleLogin = (data) => {
   return setUser(data);
@@ -24,11 +21,16 @@ export const logout = () => {
   setUser({});
   window.sessionStorage.removeItem("jwt");
   window.sessionStorage.removeItem("user");
-  navigate("/login")
+  navigate("/login");
 };
 
-export const validateSession = (jwt) => {
-  const decodedJwt = jwtDecode<JwtPayload>(jwt);
+export const validateSession = () => {
+  const token = sessionStorage.getItem("jwt");
 
-  return !(!decodedJwt || decodedJwt?.exp >= Date.now());
-}
+  if (!token) return false;
+
+  const decoded = jwtDecode<JwtPayload>(token);
+  const expired = Date.now() >= decoded.exp * 1000;
+
+  return !expired;
+};


### PR DESCRIPTION
This pull request includes:

1. Addition of `JWT` expiration validation to `gatsby-router` (which checks every time a route changes, so on every page change);
2. Addition of a generic `Send()` method within the `APIService` which is now implemented in every `resource`;
3. Addition of `JWT` expiration validation in the `Send()` method.

This results in a redirect to `/login` whenever the `JWT` expires.