### PR TITLE
Feature/gw 522/endpoints react query

### DIFF
--- a/pwa/gatsby-browser.js
+++ b/pwa/gatsby-browser.js
@@ -4,6 +4,8 @@ import { UrlContextWrapper } from "./src/context/urlContext";
 import { UserContextWrapper } from "./src/context/userContext";
 import "./src/styles/main.css";
 import "./src/styles/form.css";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 import { isLoggedIn, logout, validateSession } from "./src/services/auth";
 
@@ -17,8 +19,15 @@ export const onRouteUpdate = () => {
   }
 };
 
-export const wrapRootElement = ({ element }) => (
-  <UserContextWrapper>
-    <UrlContextWrapper>{element}</UrlContextWrapper>
-  </UserContextWrapper>
-);
+export const wrapRootElement = ({ element }) => {
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UserContextWrapper>
+        <UrlContextWrapper>{element}</UrlContextWrapper>
+      </UserContextWrapper>
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  );
+};

--- a/pwa/gatsby-browser.js
+++ b/pwa/gatsby-browser.js
@@ -20,7 +20,9 @@ export const onRouteUpdate = () => {
 };
 
 export const wrapRootElement = ({ element }) => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 5 * 60 * 1000 } },
+  });
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pwa/gatsby-ssr.js
+++ b/pwa/gatsby-ssr.js
@@ -20,7 +20,9 @@ export const onRouteUpdate = () => {
 };
 
 export const wrapRootElement = ({ element }) => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 5 * 60 * 1000 } },
+  });
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pwa/gatsby-ssr.js
+++ b/pwa/gatsby-ssr.js
@@ -3,9 +3,31 @@ import "@utrecht/design-tokens/dist/theme/index.css";
 import { UrlContextWrapper } from "./src/context/urlContext";
 import { UserContextWrapper } from "./src/context/userContext";
 import "./src/styles/main.css";
+import "./src/styles/form.css";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
-export const wrapRootElement = ({ element }) => (
-  <UserContextWrapper>
-    <UrlContextWrapper>{element}</UrlContextWrapper>
-  </UserContextWrapper>
-);
+import { isLoggedIn, logout, validateSession } from "./src/services/auth";
+
+export const onRouteUpdate = () => {
+  if (!isLoggedIn()) {
+    return;
+  }
+
+  if (!validateSession) {
+    logout();
+  }
+};
+
+export const wrapRootElement = ({ element }) => {
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UserContextWrapper>
+        <UrlContextWrapper>{element}</UrlContextWrapper>
+      </UserContextWrapper>
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  );
+};

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -33,6 +33,7 @@
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.28.0",
         "react-movable": "^3.0.2",
+        "react-query": "^3.34.16",
         "react-select": "^5.2.2",
         "react-tsparticles": "^1.41.2",
         "typescript": "^4.4.4"
@@ -10192,6 +10193,14 @@
         "node": ">8.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -10378,6 +10387,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/brorand": {
@@ -12828,6 +12852,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/detect-port": {
       "version": "1.3.0",
@@ -18424,6 +18453,11 @@
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
       "peer": true
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -18981,6 +19015,15 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/md5-file": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
@@ -19238,6 +19281,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
@@ -19599,6 +19647,14 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanocolors": {
       "version": "0.1.12",
@@ -20263,6 +20319,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -22751,6 +22812,31 @@
         "react-dom": "^16.6.0 || ^17.0.0"
       }
     },
+    "node_modules/react-query": {
+      "version": "3.34.16",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.16.tgz",
+      "integrity": "sha512-7FvBvjgEM4YQ8nPfmAr+lJfbW95uyW/TVjFoi2GwCkF33/S8ajx45tuPHPFGWs4qYwPy1mzwxD4IQfpUDrefNQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -23482,6 +23568,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
@@ -26555,6 +26646,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -35973,6 +36073,11 @@
         "open": "^7.0.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -36117,6 +36222,21 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "brorand": {
@@ -38025,6 +38145,11 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "optional": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "detect-port": {
       "version": "1.3.0",
@@ -42313,6 +42438,11 @@
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
       "peer": true
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -42772,6 +42902,15 @@
       "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
       "requires": {}
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "md5-file": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
@@ -42979,6 +43118,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -43269,6 +43413,14 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanocolors": {
       "version": "0.1.12",
@@ -43787,6 +43939,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -45613,6 +45770,16 @@
         "react-popper": "^2.2.4"
       }
     },
+    "react-query": {
+      "version": "3.34.16",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.34.16.tgz",
+      "integrity": "sha512-7FvBvjgEM4YQ8nPfmAr+lJfbW95uyW/TVjFoi2GwCkF33/S8ajx45tuPHPFGWs4qYwPy1mzwxD4IQfpUDrefNQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
@@ -46158,6 +46325,11 @@
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -48519,6 +48691,15 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
+      }
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "unpipe": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -40,6 +40,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.28.0",
     "react-movable": "^3.0.2",
+    "react-query": "^3.34.16",
     "react-select": "^5.2.2",
     "react-tsparticles": "^1.41.2",
     "typescript": "^4.4.4"

--- a/pwa/src/apiService/resources/application.ts
+++ b/pwa/src/apiService/resources/application.ts
@@ -24,7 +24,7 @@ export default class Application {
     return Send(this._instance, "POST", "/applications", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/applications/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/applications/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/attribute.ts
+++ b/pwa/src/apiService/resources/attribute.ts
@@ -28,7 +28,7 @@ export default class Entity {
     return Send(this._instance, "GET", `/attributes?entity.id=${entityId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/attributes/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/attributes/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/collection.ts
+++ b/pwa/src/apiService/resources/collection.ts
@@ -24,7 +24,7 @@ export default class Collection {
     return Send(this._instance, "POST", "/collections", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/collections/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/collections/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -8,8 +8,9 @@ export default class Endpoint {
     this._instance = _instance;
   }
 
-  public getAll = (): Promise<AxiosResponse> => {
-    return Send(this._instance, "GET", "/endpoints");
+  public getAll = async (): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", "/endpoints");
+    return data;
   };
 
   public getOne = (id: string): Promise<AxiosResponse> => {
@@ -24,7 +25,8 @@ export default class Endpoint {
     return Send(this._instance, "POST", "/endpoints", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/endpoints/${id}`);
+  public delete = async (id: string): Promise<any> => {
+    const { data } = await Send(this._instance, "DELETE", `/endpoints/${id}`);
+    return data;
   };
 }

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -35,8 +35,8 @@ export default class Endpoint {
     return data;
   };
 
-  public delete = async (id: string): Promise<any> => {
-    const { data } = await Send(this._instance, "DELETE", `/endpoints/${id}`);
+  public delete = async (variables: { id: string }): Promise<any> => {
+    const { data } = await Send(this._instance, "DELETE", `/endpoints/${variables.id}`);
     return data;
   };
 }

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -13,6 +13,15 @@ export default class Endpoint {
     return data;
   };
 
+  public getSelect = async (): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", "/endpoints");
+    const selectData = data.map((endpoint) => {
+      return { name: endpoint.name, id: endpoint.name, value: `/admin/endpoints/${endpoint.id}` };
+    });
+
+    return selectData;
+  };
+
   public getOne = async (id: string): Promise<any> => {
     const { data } = await Send(this._instance, "GET", `/endpoints/${id}`);
 

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -1,5 +1,5 @@
 import { Send } from "../apiService";
-import { AxiosInstance, AxiosResponse } from "axios";
+import { AxiosInstance } from "axios";
 
 export default class Endpoint {
   private _instance: AxiosInstance;
@@ -13,16 +13,26 @@ export default class Endpoint {
     return data;
   };
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "GET", `/endpoints/${id}`);
+  public getOne = async (id: string): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", `/endpoints/${id}`);
+
+    data.applications = data.applications.map((application) => {
+      return { label: application.name, value: `/admin/applications/${application.id}` };
+    });
+
+    return data;
   };
 
-  public createOrUpdate = (data: any, id?: string): Promise<AxiosResponse> => {
+  public createOrUpdate = async (variables: { payload: any; id: string }): Promise<any> => {
+    const { payload, id } = variables;
+
     if (id) {
-      return Send(this._instance, "PUT", `/endpoints/${id}`, data);
+      const { data } = await Send(this._instance, "PUT", `/endpoints/${id}`, payload);
+      return data;
     }
 
-    return Send(this._instance, "POST", "/endpoints", data);
+    const { data } = await Send(this._instance, "POST", "/endpoints", payload);
+    return data;
   };
 
   public delete = async (id: string): Promise<any> => {

--- a/pwa/src/apiService/resources/entity.ts
+++ b/pwa/src/apiService/resources/entity.ts
@@ -24,7 +24,7 @@ export default class Entity {
     return Send(this._instance, "POST", "/entities", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/entities/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/entities/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/handler.ts
+++ b/pwa/src/apiService/resources/handler.ts
@@ -24,7 +24,7 @@ export default class Handler {
     return Send(this._instance, "GET", `/handlers?endpoint.id=${endpointId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/handlers/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/handlers/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/source.ts
+++ b/pwa/src/apiService/resources/source.ts
@@ -24,7 +24,7 @@ export default class Source {
     return Send(this._instance, "POST", "/gateways", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/gateways/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/gateways/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/subscriber.ts
+++ b/pwa/src/apiService/resources/subscriber.ts
@@ -24,7 +24,7 @@ export default class Subscriber {
     return Send(this._instance, "GET", `/subscribers?entity.id=${entityId}`);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/subscribers/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/subscribers/${variables.id}`);
   };
 }

--- a/pwa/src/apiService/resources/translation.ts
+++ b/pwa/src/apiService/resources/translation.ts
@@ -24,8 +24,8 @@ export default class Translation {
     return Send(this._instance, "POST", "/translations", data);
   };
 
-  public delete = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/translations/${id}`);
+  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
+    return Send(this._instance, "DELETE", `/translations/${variables.id}`);
   };
 
   public getTableNames = (): Promise<AxiosResponse> => {

--- a/pwa/src/components/applications/applicationForm.tsx
+++ b/pwa/src/components/applications/applicationForm.tsx
@@ -22,6 +22,7 @@ import LoadingOverlay from "../loadingOverlay/loadingOverlay";
 import { HeaderContext } from "../../context/headerContext";
 import { AlertContext } from "../../context/alertContext";
 import MultiSelect from "../common/multiSelect";
+import { useQuery } from "react-query";
 
 interface IApplication {
   name: string;
@@ -48,6 +49,12 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({ id }) => {
   const [_, setAlert] = React.useContext(AlertContext);
   const [__, setHeader] = React.useContext(HeaderContext);
 
+  const getEndpointsSelectQuery = useQuery<any[], Error>("endpoints-select", API.Endpoint.getSelect, {
+    onError: (error) => {
+      setAlert({ message: error.message, type: "danger" });
+    },
+  });
+
   React.useEffect(() => {
     setHeader(
       <>
@@ -61,7 +68,6 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({ id }) => {
   });
 
   React.useEffect(() => {
-    handleSetEndpoints();
     id && handleSetApplications();
   }, [API, id]);
 
@@ -81,20 +87,6 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({ id }) => {
       })
       .finally(() => {
         setShowSpinner(false);
-      });
-  };
-
-  const handleSetEndpoints = () => {
-    API.Endpoint.getAll()
-      .then((res) => {
-        const _endpoints = res.data?.map((endpoint) => {
-          return { name: endpoint.name, id: endpoint.name, value: `/admin/endpoints/${endpoint.id}` };
-        });
-        setEndpoints(_endpoints);
-      })
-      .catch((err) => {
-        setAlert({ message: err, type: "danger" });
-        throw new Error("GET endpoints error: " + err);
       });
   };
 
@@ -235,6 +227,7 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({ id }) => {
                     <div className="row form-row">
                       <div className="col-6">
                         <TextareaGroup
+                          label="Description"
                           name={"description"}
                           id={"descriptionInput"}
                           defaultValue={application?.description}
@@ -255,8 +248,13 @@ export const ApplicationForm: React.FC<ApplicationFormProps> = ({ id }) => {
                           title: "Endpoints",
                           id: "endpointsAccordion",
                           render: function () {
-                            return endpoints ? (
-                              <MultiSelect id="" label="endpoints" data={application?.endpoints} options={endpoints} />
+                            return getEndpointsSelectQuery.isSuccess ? (
+                              <MultiSelect
+                                id=""
+                                label="endpoints"
+                                data={application?.endpoints}
+                                options={getEndpointsSelectQuery.data}
+                              />
                             ) : (
                               <Spinner />
                             );

--- a/pwa/src/components/applications/applicationsTable.tsx
+++ b/pwa/src/components/applications/applicationsTable.tsx
@@ -141,7 +141,10 @@ export default function ApplicationsTable() {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteApplication} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteApplication({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link to={`/applications/${item.id}`}>
                                 <button className="utrecht-button btn-sm btn-success">
                                   <FontAwesomeIcon icon={faEdit} /> Edit

--- a/pwa/src/components/attributes/attributeTable.tsx
+++ b/pwa/src/components/attributes/attributeTable.tsx
@@ -148,7 +148,10 @@ export default function AttributeTable({ entityId }) {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteAttribute} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteAttribute({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link
                                 className="utrecht-link d-flex justify-content-end"
                                 to={`/entities/${entityId}/attributes/${item.id}`}

--- a/pwa/src/components/collections/collectionTable.tsx
+++ b/pwa/src/components/collections/collectionTable.tsx
@@ -64,7 +64,11 @@ export default function CollectionTable() {
       cardHeader={function () {
         return (
           <>
-            <button className="utrecht-link button-no-style" data-bs-toggle="modal" data-bs-target="#collectionHelpModal">
+            <button
+              className="utrecht-link button-no-style"
+              data-bs-toggle="modal"
+              data-bs-target="#collectionHelpModal"
+            >
               <i className="fas fa-question mr-1" />
               <span className="mr-2">Help</span>
             </button>
@@ -108,7 +112,8 @@ export default function CollectionTable() {
                       {
                         headerName: "Date Created",
                         field: "dateCreated",
-                        renderCell: (item: { dateCreated: string }) => new Date(item.dateCreated).toLocaleString("nl-NL"),
+                        renderCell: (item: { dateCreated: string }) =>
+                          new Date(item.dateCreated).toLocaleString("nl-NL"),
                       },
                       {
                         field: "id",
@@ -123,7 +128,10 @@ export default function CollectionTable() {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteCollection} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteCollection({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link className="utrecht-link d-flex justify-content-end" to={`/collections/${item.id}`}>
                                 <button className="utrecht-button btn-sm btn-success">
                                   <FontAwesomeIcon icon={faEdit} /> Edit

--- a/pwa/src/components/common/layout.tsx
+++ b/pwa/src/components/common/layout.tsx
@@ -12,8 +12,6 @@ import WelcomeModal from "../welcomeModal/welcomeModal";
 import Alert from "../alert/alert";
 import { HeaderProvider } from "../../context/headerContext";
 import Header from "./header";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { ReactQueryDevtools } from "react-query/devtools";
 
 /**
  * This components renders a layout which is renders the menu, footer and container surrounding main body of pages.
@@ -26,8 +24,6 @@ export default function Layout({ children, pageContext }) {
   const [alert, setAlert] = React.useState<AlertProps>(null);
   const [header, setHeader] = React.useState(null);
 
-  const queryClient = new QueryClient();
-
   React.useEffect(() => {
     if (!isLoggedIn()) {
       setAPI(null);
@@ -39,32 +35,29 @@ export default function Layout({ children, pageContext }) {
   }, [API, isLoggedIn()]);
 
   return API ? (
-    <QueryClientProvider client={queryClient}>
-      <APIProvider value={API}>
-        <AlertProvider value={[alert, setAlert]}>
-          <HeaderProvider value={[header, setHeader]}>
-            <Alert />
-            <Helmet>
-              <title>Conductor Admin Dashboard</title>
-            </Helmet>
-            <div className="utrecht-document conduction-theme">
-              <div className="utrecht-page">
-                <MainMenu />
-                <div className="utrecht-page__content">
-                  <header className="utrecht-page-header">
-                    <Header {...{ pageContext }} />
-                  </header>
-                  <div className="container py-4">{children}</div>
-                </div>
-                <Footer />
+    <APIProvider value={API}>
+      <AlertProvider value={[alert, setAlert]}>
+        <HeaderProvider value={[header, setHeader]}>
+          <Alert />
+          <Helmet>
+            <title>Conductor Admin Dashboard</title>
+          </Helmet>
+          <div className="utrecht-document conduction-theme">
+            <div className="utrecht-page">
+              <MainMenu />
+              <div className="utrecht-page__content">
+                <header className="utrecht-page-header">
+                  <Header {...{ pageContext }} />
+                </header>
+                <div className="container py-4">{children}</div>
               </div>
+              <Footer />
             </div>
-            <WelcomeModal />
-            <ReactQueryDevtools />
-          </HeaderProvider>
-        </AlertProvider>
-      </APIProvider>
-    </QueryClientProvider>
+          </div>
+          <WelcomeModal />
+        </HeaderProvider>
+      </AlertProvider>
+    </APIProvider>
   ) : (
     <Login />
   );

--- a/pwa/src/components/common/layout.tsx
+++ b/pwa/src/components/common/layout.tsx
@@ -12,6 +12,8 @@ import WelcomeModal from "../welcomeModal/welcomeModal";
 import Alert from "../alert/alert";
 import { HeaderProvider } from "../../context/headerContext";
 import Header from "./header";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 /**
  * This components renders a layout which is renders the menu, footer and container surrounding main body of pages.
@@ -24,6 +26,8 @@ export default function Layout({ children, pageContext }) {
   const [alert, setAlert] = React.useState<AlertProps>(null);
   const [header, setHeader] = React.useState(null);
 
+  const queryClient = new QueryClient();
+
   React.useEffect(() => {
     if (!isLoggedIn()) {
       setAPI(null);
@@ -35,29 +39,32 @@ export default function Layout({ children, pageContext }) {
   }, [API, isLoggedIn()]);
 
   return API ? (
-    <APIProvider value={API}>
-      <AlertProvider value={[alert, setAlert]}>
-        <HeaderProvider value={[header, setHeader]}>
-          <Alert />
-          <Helmet>
-            <title>Conductor Admin Dashboard</title>
-          </Helmet>
-          <div className="utrecht-document conduction-theme">
-            <div className="utrecht-page">
-              <MainMenu />
-              <div className="utrecht-page__content">
-                <header className="utrecht-page-header">
-                  <Header {...{ pageContext }} />
-                </header>
-                <div className="container py-4">{children}</div>
+    <QueryClientProvider client={queryClient}>
+      <APIProvider value={API}>
+        <AlertProvider value={[alert, setAlert]}>
+          <HeaderProvider value={[header, setHeader]}>
+            <Alert />
+            <Helmet>
+              <title>Conductor Admin Dashboard</title>
+            </Helmet>
+            <div className="utrecht-document conduction-theme">
+              <div className="utrecht-page">
+                <MainMenu />
+                <div className="utrecht-page__content">
+                  <header className="utrecht-page-header">
+                    <Header {...{ pageContext }} />
+                  </header>
+                  <div className="container py-4">{children}</div>
+                </div>
+                <Footer />
               </div>
-              <Footer />
             </div>
-          </div>
-          <WelcomeModal />
-        </HeaderProvider>
-      </AlertProvider>
-    </APIProvider>
+            <WelcomeModal />
+            <ReactQueryDevtools />
+          </HeaderProvider>
+        </AlertProvider>
+      </APIProvider>
+    </QueryClientProvider>
   ) : (
     <Login />
   );

--- a/pwa/src/components/deleteModal/DeleteModal.tsx
+++ b/pwa/src/components/deleteModal/DeleteModal.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash, faTimes } from "@fortawesome/free-solid-svg-icons";
 
 interface DeleteModalProps {
-  resourceDelete: (resourceId) => void;
+  resourceDelete: (id) => void;
   resourceId: string;
   optionalMessage?: JSX.Element;
 }
@@ -28,7 +28,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({ resourceDelete, resourceId, o
               </button>
               <button
                 className="utrecht-button btn-sm btn-danger mr-2"
-                onClick={() => resourceDelete(resourceId)}
+                onClick={(id) => resourceDelete(id)}
                 data-bs-dismiss="modal"
               >
                 <FontAwesomeIcon icon={faTrash} /> Delete

--- a/pwa/src/components/endpoints/endpointForm.tsx
+++ b/pwa/src/components/endpoints/endpointForm.tsx
@@ -47,13 +47,13 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
    */
   const queryClient = useQueryClient();
 
-  const getEndpoint =
-    endpointId &&
-    useQuery<any, Error>(["endpoints", endpointId], () => API.Endpoint.getOne(endpointId), {
-      onError: (error) => {
-        setAlert({ message: error.message, type: "danger" });
-      },
-    });
+  const getEndpoint = useQuery<any, Error>(["endpoints", endpointId], () => API.Endpoint.getOne(endpointId), {
+    initialData: () => queryClient.getQueryData<any[]>("endpoints")?.find((endpoint) => endpoint.id === endpointId),
+    onError: (error) => {
+      setAlert({ message: error.message, type: "danger" });
+    },
+    enabled: !!endpointId,
+  });
 
   const createOrEditEndpoint = useMutation<any, Error, any>(API.Endpoint.createOrUpdate, {
     onMutate: () => {
@@ -78,7 +78,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
   React.useEffect(() => {
     setHeader("Endpoint");
 
-    if (getEndpoint?.isSuccess) {
+    if (getEndpoint.isSuccess) {
       setHeader(
         <>
           Endpoint: <i>{getEndpoint.data.name}</i>
@@ -89,7 +89,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
         setValue(field, getEndpoint.data[field]);
       });
     }
-  }, [getEndpoint?.isSuccess]);
+  }, [getEndpoint.isSuccess]);
 
   React.useEffect(() => {
     handleSetApplications();
@@ -162,7 +162,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
           return (
             <div className="row">
               <div className="col-12">
-                {getEndpoint?.isLoading ? (
+                {getEndpoint.isLoading ? (
                   <Spinner />
                 ) : (
                   <div>

--- a/pwa/src/components/endpoints/endpointForm.tsx
+++ b/pwa/src/components/endpoints/endpointForm.tsx
@@ -9,13 +9,13 @@ import { AlertContext } from "../../context/alertContext";
 import { HeaderContext } from "../../context/headerContext";
 import { useForm } from "react-hook-form";
 import { InputText, Textarea, SelectMultiple } from "../formFields";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 
 interface EndpointFormProps {
   endpointId: string;
 }
 
 export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
-  const [showSpinner, setShowSpinner] = React.useState<boolean>(false);
   const [applications, setApplications] = React.useState<any>(null);
   const [loadingOverlay, setLoadingOverlay] = React.useState<boolean>(false);
   const title: string = endpointId ? "Edit Endpoint" : "Create Endpoint";
@@ -23,6 +23,10 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
   const [documentation, setDocumentation] = React.useState<string>(null);
   const [_, setAlert] = React.useContext(AlertContext);
   const [__, setHeader] = React.useContext(HeaderContext);
+
+  /**
+   * Form fields and logic
+   */
   const fields = ["name", "path", "description", "applications"];
 
   const {
@@ -33,36 +37,63 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
     control,
   } = useForm();
 
+  const onSubmit = (data): void => {
+    data.applications = data.applications.map((application) => application.value);
+    createOrEditEndpoint.mutate({ payload: data, id: endpointId });
+  };
+
+  /**
+   * Queries and mutations
+   */
+  const queryClient = useQueryClient();
+
+  const getEndpoint =
+    endpointId &&
+    useQuery<any, Error>(["endpoints", endpointId], () => API.Endpoint.getOne(endpointId), {
+      onError: (error) => {
+        setAlert({ message: error.message, type: "danger" });
+      },
+    });
+
+  const createOrEditEndpoint = useMutation<any, Error, any>(API.Endpoint.createOrUpdate, {
+    onMutate: () => {
+      setLoadingOverlay(true);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries("endpoints");
+      setAlert({ message: `${endpointId ? "Updated" : "Created"} endpoint`, type: "success" });
+      navigate("/endpoints");
+    },
+    onError: (error) => {
+      setAlert({ message: error.message, type: "danger" });
+    },
+    onSettled: () => {
+      setLoadingOverlay(false);
+    },
+  });
+
+  /**
+   * Effects
+   */
+  React.useEffect(() => {
+    setHeader("Endpoint");
+
+    if (getEndpoint?.isSuccess) {
+      setHeader(
+        <>
+          Endpoint: <i>{getEndpoint.data.name}</i>
+        </>,
+      );
+
+      fields.map((field) => {
+        setValue(field, getEndpoint.data[field]);
+      });
+    }
+  }, [getEndpoint?.isSuccess]);
+
   React.useEffect(() => {
     handleSetApplications();
-    endpointId && handleSetEndpoint();
   }, [API, endpointId]);
-
-  const handleSetEndpoint = () => {
-    setShowSpinner(true);
-
-    API.Endpoint.getOne(endpointId)
-      .then((res) => {
-        setHeader(res.data.name);
-
-        const endpoint = res.data;
-
-        endpoint.applications = res.data.applications.map((endpoint) => {
-          return { label: endpoint.name, value: `/admin/applications/${endpoint.id}` };
-        });
-
-        fields.map((field) => {
-          setValue(field, endpoint[field]);
-        });
-      })
-      .catch((err) => {
-        setAlert({ message: err, type: "danger" });
-        throw new Error("GET endpoints error: " + err);
-      })
-      .finally(() => {
-        setShowSpinner(false);
-      });
-  };
 
   const handleSetApplications = () => {
     API.Application.getAll()
@@ -86,24 +117,6 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
       .catch((err) => {
         setAlert({ message: err, type: "danger" });
         throw new Error("GET Documentation error: " + err);
-      });
-  };
-
-  const onSubmit = (data): void => {
-    setLoadingOverlay(true);
-
-    data.applications = data.applications.map((application) => application.value);
-
-    API.Endpoint.createOrUpdate(data, endpointId)
-      .then(() => {
-        setAlert({ message: `${endpointId ? "Updated" : "Created"} endpoint`, type: "success" });
-      })
-      .catch((err) => {
-        setAlert({ type: "danger", message: err.message });
-        throw new Error(`Create or update endpoint error: ${err}`);
-      })
-      .finally(() => {
-        navigate("/endpoints");
       });
   };
 
@@ -149,7 +162,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
           return (
             <div className="row">
               <div className="col-12">
-                {showSpinner === true ? (
+                {getEndpoint?.isLoading ? (
                   <Spinner />
                 ) : (
                   <div>

--- a/pwa/src/components/endpoints/endpointForm.tsx
+++ b/pwa/src/components/endpoints/endpointForm.tsx
@@ -75,6 +75,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
         queryClient.setQueryData(["endpoints", newEndpoint.id], newEndpoint);
       }
 
+      queryClient.invalidateQueries("endpoints");
       setAlert({ message: `${endpointId ? "Updated" : "Created"} endpoint`, type: "success" });
       navigate("/endpoints");
     },
@@ -83,7 +84,6 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
     },
     onSettled: () => {
       setLoadingOverlay(false);
-      queryClient.invalidateQueries("endpoints");
     },
   });
 

--- a/pwa/src/components/endpoints/endpointForm.tsx
+++ b/pwa/src/components/endpoints/endpointForm.tsx
@@ -38,7 +38,7 @@ export const EndpointForm: React.FC<EndpointFormProps> = ({ endpointId }) => {
   } = useForm();
 
   const onSubmit = (data): void => {
-    data.applications = data.applications.map((application) => application.value);
+    data.applications = data.applications?.map((application) => application.value);
     createOrEditEndpoint.mutate({ payload: data, id: endpointId });
   };
 

--- a/pwa/src/components/endpoints/endpointsTable.tsx
+++ b/pwa/src/components/endpoints/endpointsTable.tsx
@@ -9,10 +9,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash, faEdit } from "@fortawesome/free-solid-svg-icons";
 import DeleteModal from "../deleteModal/DeleteModal";
 import { useMutation, useQuery, useQueryClient } from "react-query";
+import LoadingOverlay from "../loadingOverlay/loadingOverlay";
 
 export default function EndpointsTable() {
   const API: APIService = React.useContext(APIContext);
   const [documentation, setDocumentation] = React.useState<string>(null);
+  const [loadingOverlay, setLoadingOverlay] = React.useState<boolean>(false);
   const [_, setAlert] = React.useContext(AlertContext);
   const [__, setHeader] = React.useContext(HeaderContext);
 
@@ -25,6 +27,9 @@ export default function EndpointsTable() {
   });
 
   const deleteEndpointMutation = useMutation<any, Error, any>(API.Endpoint.delete, {
+    onMutate: () => {
+      setLoadingOverlay(true);
+    },
     onError: (error) => {
       setAlert({ message: error.message, type: "danger" });
     },
@@ -37,6 +42,9 @@ export default function EndpointsTable() {
 
       queryClient.invalidateQueries("endpoints");
       setAlert({ message: "Deleted endpoint", type: "success" });
+    },
+    onSettled: () => {
+      setLoadingOverlay(false);
     },
   });
 
@@ -102,6 +110,7 @@ export default function EndpointsTable() {
                 <Spinner />
               ) : (
                 <>
+                  {loadingOverlay && <LoadingOverlay />}
                   <Table
                     columns={[
                       {

--- a/pwa/src/components/entities/entitiesTable.tsx
+++ b/pwa/src/components/entities/entitiesTable.tsx
@@ -144,7 +144,10 @@ export default function EntitiesTable() {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteObjectType} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteObjectType({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link className="utrecht-link d-flex justify-content-end" to={`/entities/${item.id}`}>
                                 <button className="utrecht-button btn-sm btn-success">
                                   <FontAwesomeIcon icon={faEdit} /> Edit

--- a/pwa/src/components/handlers/handlerTable.tsx
+++ b/pwa/src/components/handlers/handlerTable.tsx
@@ -130,7 +130,10 @@ export default function HandlersTable({ endpointId }) {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteHandler} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteHandler({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link
                                 className="utrecht-link d-flex justify-content-end"
                                 to={`/endpoints/${endpointId}/handlers/${item.id}/`}

--- a/pwa/src/components/sources/sourcesTable.tsx
+++ b/pwa/src/components/sources/sourcesTable.tsx
@@ -133,7 +133,10 @@ export default function SourcesTable() {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteSource} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteSource({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link className="utrecht-link d-flex justify-content-end" to={`/sources/${item.id}`}>
                                 <button className="utrecht-button btn-sm btn-success">
                                   <FontAwesomeIcon icon={faEdit} /> Edit

--- a/pwa/src/components/subscribers/subscriberForm.tsx
+++ b/pwa/src/components/subscribers/subscriberForm.tsx
@@ -24,6 +24,7 @@ import { AlertContext } from "../../context/alertContext";
 import { HeaderContext } from "../../context/headerContext";
 import MultiSelect from "../common/multiSelect";
 import { validateJSON } from "../../services/validateJSON";
+import { useQuery } from "react-query";
 
 interface SubscriberFormProps {
   subscriberId: string;
@@ -39,8 +40,17 @@ export const SubscriberForm: React.FC<SubscriberFormProps> = ({ subscriberId, en
   const [_, setAlert] = React.useContext(AlertContext);
   const [__, setHeader] = React.useContext(HeaderContext);
   const [sources, setSources] = React.useState<any>(null);
-  const [endpoints, setEndpoint] = React.useState<any>(null);
   const [tableNames, setTableNames] = React.useState<Array<any>>(null);
+
+  const getEndpointsSelectQuery = useQuery<any[], Error>("endpoints-select", API.Endpoint.getSelect, {
+    onError: (error) => {
+      console.log("error!!");
+      setAlert({ message: error.message, type: "danger" });
+    },
+    onSuccess: () => {
+      console.log("success");
+    },
+  });
 
   React.useEffect(() => {
     setHeader(
@@ -53,13 +63,12 @@ export const SubscriberForm: React.FC<SubscriberFormProps> = ({ subscriberId, en
   React.useEffect(() => {
     subscriberId && handleSetSubscriber();
     handleSetSources();
-    handleSetEndpoints();
     handleSetTableNames();
   }, [API, subscriberId]);
 
   React.useEffect(() => {
-    setShowSpinner(!sources || !endpoints || !tableNames || (subscriberId && !subscriber));
-  }, [subscriber, sources, endpoints, tableNames, subscriberId]);
+    setShowSpinner(!sources || !getEndpointsSelectQuery.isSuccess || !tableNames || (subscriberId && !subscriber));
+  }, [subscriber, sources, getEndpointsSelectQuery.isSuccess, tableNames, subscriberId]);
 
   const handleSetSubscriber = () => {
     API.Subscriber.getOne(subscriberId)
@@ -80,17 +89,6 @@ export const SubscriberForm: React.FC<SubscriberFormProps> = ({ subscriberId, en
       .catch((err) => {
         setAlert({ message: err, type: "danger" });
         throw new Error("GET sources error: " + err);
-      });
-  };
-
-  const handleSetEndpoints = () => {
-    API.Endpoint.getAll()
-      .then((res) => {
-        setEndpoint(res.data);
-      })
-      .catch((err) => {
-        setAlert({ message: err, type: "danger" });
-        throw new Error("GET endpoints error: " + err);
       });
   };
 
@@ -209,6 +207,7 @@ export const SubscriberForm: React.FC<SubscriberFormProps> = ({ subscriberId, en
                       </div>
                       <div className="col-6">
                         <TextareaGroup
+                          label="Description"
                           name={"description"}
                           id={"descriptionInput"}
                           defaultValue={subscriber?.description}
@@ -281,11 +280,7 @@ export const SubscriberForm: React.FC<SubscriberFormProps> = ({ subscriberId, en
                       </div>
                       <div className="col-6">
                         <SelectInputComponent
-                          options={
-                            endpoints !== null && endpoints.length > 0
-                              ? endpoints
-                              : [{ name: "Please create an endpoint first.", value: null }]
-                          }
+                          options={getEndpointsSelectQuery.data ?? []}
                           data={subscriber?.endpoint?.name}
                           name={"endpoint"}
                           id={"endpointInput"}

--- a/pwa/src/components/subscribers/subscribersTable.tsx
+++ b/pwa/src/components/subscribers/subscribersTable.tsx
@@ -114,7 +114,10 @@ export default function SubscribersTable({ entityId }) {
                               >
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
-                              <DeleteModal resourceDelete={handleDeleteSubscriber} resourceId={item.id} />
+                              <DeleteModal
+                                resourceDelete={() => handleDeleteSubscriber({ id: item.id })}
+                                resourceId={item.id}
+                              />
                               <Link
                                 className="utrecht-link d-flex justify-content-end"
                                 to={`/entities/${entityId}/subscribers/${item.id}`}

--- a/pwa/src/components/translations/translationTable.tsx
+++ b/pwa/src/components/translations/translationTable.tsx
@@ -145,7 +145,7 @@ export default function TranslationTable({ tableName }) {
                                 <FontAwesomeIcon icon={faTrash} /> Delete
                               </button>
                               <DeleteModal
-                                resourceDelete={handleDeleteTranslation}
+                                resourceDelete={() => handleDeleteTranslation({ id: item.id })}
                                 resourceId={item.id}
                                 optionalMessage={
                                   translations.length === 1 && (

--- a/pwa/src/templates/dashboard/Dashboard.tsx
+++ b/pwa/src/templates/dashboard/Dashboard.tsx
@@ -13,19 +13,21 @@ import endpointsIcon from "./../../images/icon-endpoints.svg";
 import conductionIcon from "./../../images/icon-conduction.svg";
 import Spinner from "../../components/common/spinner";
 import { Card, Modal } from "@conductionnl/nl-design-system";
+import { useQuery } from "react-query";
 
 const Dashboard: React.FC = () => {
   const [logs, setLogs] = React.useState(null);
   const [logsDocumentation, setLogsDocumentation] = React.useState(null);
   const [applicationsCount, setApplicationsCount] = React.useState<number>(0);
   const [sourcesCount, setSourcesCount] = React.useState<number>(0);
-  const [endpointsCount, setEndpointsCount] = React.useState<number>(0);
   const API: APIService = React.useContext(APIContext);
 
   React.useEffect(() => {
     handleSetCounts();
     handleSetLogs();
   }, [API]);
+
+  const getEndpointsQuery = useQuery<any[], Error>("endpoints", API.Endpoint.getAll);
 
   const handleSetLogs = (): void => {
     logs && setLogs(null);
@@ -65,14 +67,6 @@ const Dashboard: React.FC = () => {
       .catch((err) => {
         throw new Error(`GET sources error: ${err}`);
       });
-
-    API.Endpoint.getAll()
-      .then((res) => {
-        setEndpointsCount(res.data.length);
-      })
-      .catch((err) => {
-        throw new Error(`GET endpoints error: ${err}`);
-      });
   };
 
   return (
@@ -99,7 +93,7 @@ const Dashboard: React.FC = () => {
           />
 
           <DashboardCard
-            amount={endpointsCount}
+            amount={getEndpointsQuery.isSuccess ? getEndpointsQuery.data.length : 0}
             title="Endpoints"
             iconBackgroundColor="31CE36"
             icon={<img src={endpointsIcon} alt="endpoints" />}


### PR DESCRIPTION
This pull request includes:

- Addition of `react-query`
- Implementation of `react-query` in `Endpoints` (and all forms that require `endpoints`)

It also includes the following details:

- `staleTime` is set to 5 minutes (meaning calls are valid for five minutes, except for when we invalidate them ourselves)
- Optimistic update, create and delete is set on resource details
- Optimistic GET is set on resource details (they are grabbed from the list query)

Note 1: To get optimistic deletion to work, I had to update the `DeleteModal` and its implementations and its linked `APIService` methods.

Note 2: The collections form seems to be broken (I think it already was broken before this update).