### PR TITLE
Feature/gw 577/resource to select array

### DIFF
--- a/pwa/gatsby-browser.js
+++ b/pwa/gatsby-browser.js
@@ -20,9 +20,7 @@ export const onRouteUpdate = () => {
 };
 
 export const wrapRootElement = ({ element }) => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { staleTime: 5 * 60 * 1000 } },
-  });
+  const queryClient = new QueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pwa/gatsby-ssr.js
+++ b/pwa/gatsby-ssr.js
@@ -20,9 +20,7 @@ export const onRouteUpdate = () => {
 };
 
 export const wrapRootElement = ({ element }) => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { staleTime: 5 * 60 * 1000 } },
-  });
+  const queryClient = new QueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -1,5 +1,6 @@
 import { Send } from "../apiService";
 import { AxiosInstance } from "axios";
+import { resourceArrayToSelectArray } from "./../../services/resourceArrayToSelectArray";
 
 export default class Endpoint {
   private _instance: AxiosInstance;
@@ -25,9 +26,7 @@ export default class Endpoint {
   public getOne = async (id: string): Promise<any> => {
     const { data } = await Send(this._instance, "GET", `/endpoints/${id}`);
 
-    data.applications = data.applications.map((application) => {
-      return { label: application.name, value: `/admin/applications/${application.id}` };
-    });
+    data.applications = resourceArrayToSelectArray(data.applications, "applications");
 
     return data;
   };

--- a/pwa/src/apiService/resources/endpoint.ts
+++ b/pwa/src/apiService/resources/endpoint.ts
@@ -16,6 +16,7 @@ export default class Endpoint {
 
   public getSelect = async (): Promise<any> => {
     const { data } = await Send(this._instance, "GET", "/endpoints");
+
     const selectData = data.map((endpoint) => {
       return { name: endpoint.name, id: endpoint.name, value: `/admin/endpoints/${endpoint.id}` };
     });

--- a/pwa/src/services/resourceArrayToSelectArray.ts
+++ b/pwa/src/services/resourceArrayToSelectArray.ts
@@ -1,0 +1,10 @@
+interface ISelectOption {
+  label: string;
+  value: string;
+}
+
+export const resourceArrayToSelectArray = (resourceArray: any[], resourceName: string): ISelectOption[] => {
+  return resourceArray.map((resource) => {
+    return { label: resource.name, value: `/admin/${resourceName}/${resource.id}` };
+  });
+};


### PR DESCRIPTION
This pull request includes:

- Removal of `staleTime` on queries (back to `react-query` standard configuration to ensure that stale queries are re-fetched);
- Addition of `resourceArrayToSelectArray` method to make the mapping generic.

Note: the `resourceArrayToSelectArray` method can only be implemented in all _new_ `Select` and `SelectMulti` implementations (meaning that it's now only implemented in `Endpoint`).