### PR TITLE
Feature/gw 619/generic tooltip

### DIFF
--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -35,8 +35,10 @@
         "react-movable": "^3.0.2",
         "react-query": "^3.34.16",
         "react-select": "^5.2.2",
+        "react-tooltip": "^4.2.21",
         "react-tsparticles": "^1.41.2",
-        "typescript": "^4.4.4"
+        "typescript": "^4.4.4",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "dotenv": "^10.0.0",
@@ -22975,6 +22977,30 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
+      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "npm": ">=6.13"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/react-tooltip/node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -45897,6 +45923,22 @@
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.0.0",
         "use-latest": "^1.0.0"
+      }
+    },
+    "react-tooltip": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
+      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
       }
     },
     "react-transition-group": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -42,8 +42,10 @@
     "react-movable": "^3.0.2",
     "react-query": "^3.34.16",
     "react-select": "^5.2.2",
+    "react-tooltip": "^4.2.21",
     "react-tsparticles": "^1.41.2",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "dotenv": "^10.0.0",

--- a/pwa/src/components/formFields/createArray/createArray.tsx
+++ b/pwa/src/components/formFields/createArray/createArray.tsx
@@ -20,10 +20,11 @@ export const CreateArray: React.FC<CreateArrayProps & IFormFieldProps & IReactHo
   errors,
   control,
   validation,
+  tooltipContent,
   data,
 }) => {
   return (
-    <FormFieldGroup {...{ name, label, errors }} required={!!validation?.required}>
+    <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
       <Controller
         {...{ control, name }}
         rules={validation}

--- a/pwa/src/components/formFields/createKeyValue/createKeyValue.tsx
+++ b/pwa/src/components/formFields/createKeyValue/createKeyValue.tsx
@@ -25,10 +25,11 @@ export const CreateKeyValue: React.FC<CreateKeyValueProps & IFormFieldProps & IR
   errors,
   control,
   validation,
+  tooltipContent,
   data,
 }) => {
   return (
-    <FormFieldGroup {...{ name, label, errors }} required={!!validation?.required}>
+    <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
       <Controller
         {...{ control, name }}
         rules={validation}

--- a/pwa/src/components/formFields/formFieldGroup/formFieldGroup.css
+++ b/pwa/src/components/formFields/formFieldGroup/formFieldGroup.css
@@ -1,3 +1,11 @@
+.FormField-group > label {
+  display: flex;
+}
+
+.FormField-group .FormField-tooltip {
+  margin-left: 5px;
+}
+
 .FormField-group .FormField-group-errorMessage {
   color: #dc3545;
 }

--- a/pwa/src/components/formFields/formFieldGroup/formFieldGroup.tsx
+++ b/pwa/src/components/formFields/formFieldGroup/formFieldGroup.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import "./formFieldGroup.css";
 import { FieldErrors } from "react-hook-form";
 import { IFormFieldProps } from "../types";
+import { Tooltip } from "./../../tooltip/tooltip";
 
 interface IFormFieldGroupProps {
   errors: FieldErrors;
@@ -16,6 +17,11 @@ export const FormFieldGroup: React.FC<IFormFieldGroupProps & IFormFieldProps> = 
       <label htmlFor={props.name}>
         {props.label}
         {props.required && <b>*</b>}
+        {props.tooltipContent && (
+          <span className="FormField-tooltip">
+            <Tooltip content={props.tooltipContent} />
+          </span>
+        )}
       </label>
       {props.children}
 

--- a/pwa/src/components/formFields/input.tsx
+++ b/pwa/src/components/formFields/input.tsx
@@ -12,9 +12,10 @@ export const Input: React.FC<IInputProps & IFormFieldProps & IReactHookFormProps
   label,
   errors,
   validation,
+  tooltipContent,
   register,
 }) => (
-  <FormFieldGroup {...{ name, label, errors }} required={!!validation?.required}>
+  <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
     <input id={name} className="FormField-field" {...{ label, type, ...register(name, { ...validation }) }} />
   </FormFieldGroup>
 );

--- a/pwa/src/components/formFields/select.tsx
+++ b/pwa/src/components/formFields/select.tsx
@@ -15,10 +15,11 @@ export const SelectMultiple: React.FC<ISelectProps & IFormFieldProps & IReactHoo
   options,
   errors,
   control,
+  tooltipContent,
   validation,
 }) => {
   return (
-    <FormFieldGroup {...{ name, label, errors }} required={!!validation?.required}>
+    <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
       <Controller
         {...{ control, name }}
         rules={validation}
@@ -36,10 +37,11 @@ export const SelectSingle: React.FC<ISelectProps & IFormFieldProps & IReactHookF
   options,
   errors,
   control,
+  tooltipContent,
   validation,
 }) => {
   return (
-    <FormFieldGroup {...{ name, label, errors }} required={!!validation?.required}>
+    <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
       <Controller
         {...{ control, name }}
         rules={validation}

--- a/pwa/src/components/formFields/textarea.tsx
+++ b/pwa/src/components/formFields/textarea.tsx
@@ -8,9 +8,10 @@ export const Textarea: React.FC<IFormFieldProps & IReactHookFormProps> = ({
   label,
   errors,
   validation,
+  tooltipContent,
   register,
 }) => (
-  <FormFieldGroup {...{ name, label, errors }} required={validation?.required}>
+  <FormFieldGroup {...{ name, label, errors, tooltipContent }} required={!!validation?.required}>
     <textarea id={name} className="FormField-field" {...{ label, ...register(name, { ...validation }) }} />
   </FormFieldGroup>
 );

--- a/pwa/src/components/formFields/types.ts
+++ b/pwa/src/components/formFields/types.ts
@@ -9,6 +9,7 @@ export interface IReactHookFormProps {
 export interface IFormFieldProps {
   label: string;
   name: string;
+  tooltipContent?: JSX.Element | string;
 }
 
 export interface ISelectValue {

--- a/pwa/src/components/tooltip/tooltip.css
+++ b/pwa/src/components/tooltip/tooltip.css
@@ -1,0 +1,13 @@
+.Tooltip > .Tooltip-button {
+  cursor: pointer;
+  color: var(--utrecht-topnav-list-background-color);
+}
+
+.Tooltip > .Tooltip-tooltip {
+  pointer-events: auto !important;
+}
+
+.Tooltip > .Tooltip-tooltip:hover {
+  visibility: visible !important;
+  opacity: 1 !important;
+}

--- a/pwa/src/components/tooltip/tooltip.tsx
+++ b/pwa/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import "./tooltip.css";
+import ReactTooltip from "react-tooltip";
+import { v4 as uuidv4 } from "uuid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+
+interface TooltipProps {
+  content: JSX.Element | string;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ content }) => {
+  const uuid = uuidv4();
+
+  return (
+    <div className="Tooltip">
+      <FontAwesomeIcon icon={faInfoCircle} data-tip data-for={uuid} className="Tooltip-button" />
+
+      <ReactTooltip id={uuid} className="Tooltip-tooltip" delayHide={250} effect="solid">
+        {content}
+      </ReactTooltip>
+    </div>
+  );
+};


### PR DESCRIPTION
Read commit messages for made changes.

How to implement:

In any input component (e.g. `<InputText />`) you can now pass the `tooltipContent` prop to automatically create a tooltip next to the label, like so:

```
<InputText
  label="Name"
  name="name"
  tooltipContent="Content goes here" <== string implementation
  {...{ register, errors }}
  validation={{ required: true }}
/>
```

```
<InputText
  label="Name"
  name="name"
  tooltipContent={<>Content goes here</>} <== JSX.Element implementation
  {...{ register, errors }}
  validation={{ required: true }}
/>
```