### PR TITLE
IMPLEMENT react-query for handler resource

### DIFF
--- a/pwa/src/apiService/resources/handler.ts
+++ b/pwa/src/apiService/resources/handler.ts
@@ -1,5 +1,5 @@
 import { Send } from "../apiService";
-import { AxiosInstance, AxiosResponse } from "axios";
+import { AxiosInstance } from "axios";
 
 export default class Handler {
   private _instance: AxiosInstance;
@@ -8,23 +8,32 @@ export default class Handler {
     this._instance = _instance;
   }
 
-  public getOne = (id: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "GET", `/handlers/${id}`);
+  public getOne = async (id: string): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", `/handlers/${id}`);
+
+    return data;
   };
 
-  public createOrUpdate = (data: any, id?: string): Promise<AxiosResponse> => {
+  public getAllFromEndpoint = async (endpointId: string): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", `/handlers?endpoints.id=${endpointId}`);
+
+    return data;
+  };
+
+  public createOrUpdate = async (variables: { payload: any; id: string }): Promise<any> => {
+    const { payload, id } = variables;
+
     if (id) {
-      return Send(this._instance, "PUT", `/handlers/${id}`, data);
+      const { data } = await Send(this._instance, "PUT", `/handlers/${id}`, payload);
+      return data;
     }
 
-    return Send(this._instance, "POST", "/handlers", data);
+    const { data } = await Send(this._instance, "POST", "/handlers", payload);
+    return data;
   };
 
-  public getAllFromEndpoint = (endpointId: string): Promise<AxiosResponse> => {
-    return Send(this._instance, "GET", `/handlers?endpoints.id=${endpointId}`);
-  };
-
-  public delete = (variables: { id: string }): Promise<AxiosResponse> => {
-    return Send(this._instance, "DELETE", `/handlers/${variables.id}`);
+  public delete = async (variables: { id: string }): Promise<any> => {
+    const { data } = await Send(this._instance, "DELETE", `/handlers/${variables.id}`);
+    return data;
   };
 }

--- a/pwa/src/components/handlers/handlerTable.tsx
+++ b/pwa/src/components/handlers/handlerTable.tsx
@@ -4,39 +4,26 @@ import { Link } from "gatsby";
 import APIService from "../../apiService/apiService";
 import APIContext from "../../apiService/apiContext";
 import { AlertContext } from "../../context/alertContext";
-import { LoadingOverlayContext } from "../../context/loadingOverlayContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEdit, faTrash } from "@fortawesome/free-solid-svg-icons";
 import DeleteModal from "../deleteModal/DeleteModal";
+import { useQueryClient } from "react-query";
+import { useHandler } from "./../../hooks/handler";
 
 export default function HandlersTable({ endpointId }) {
   const [documentation, setDocumentation] = React.useState<string>(null);
-  const [handlers, setHandlers] = React.useState(null);
-  const [showSpinner, setShowSpinner] = React.useState(false);
   const API: APIService = React.useContext(APIContext);
   const title: string = endpointId === "new" ? "Create Handler" : "Edit Handler";
   const [_, setAlert] = React.useContext(AlertContext);
-  const [__, setLoadingOverlay] = React.useContext(LoadingOverlayContext);
+
+  const queryClient = useQueryClient();
+  const _useHandler = useHandler(queryClient);
+  const getHandlers = _useHandler.getAllFromEndpoint(endpointId);
+  const deleteHandler = _useHandler.remove();
 
   React.useEffect(() => {
-    handleSetHandlers();
     handleSetDocumentation();
   }, [API]);
-
-  const handleSetHandlers = () => {
-    setShowSpinner(true);
-    API.Handler.getAllFromEndpoint(endpointId)
-      .then((res) => {
-        setHandlers(res.data);
-      })
-      .catch((err) => {
-        setAlert({ message: err, type: "danger" });
-        throw new Error("GET handler from endpoint error: " + err);
-      })
-      .finally(() => {
-        setShowSpinner(false);
-      });
-  };
 
   const handleSetDocumentation = (): void => {
     API.Documentation.get("attributes")
@@ -46,22 +33,6 @@ export default function HandlersTable({ endpointId }) {
       .catch((err) => {
         setAlert({ message: err, type: "danger" });
         throw new Error("GET Documentation error: " + err);
-      });
-  };
-
-  const handleDeleteHandler = (id): void => {
-    setLoadingOverlay({ isLoading: true });
-    API.Handler.delete(id)
-      .then(() => {
-        setAlert({ message: "Deleted handler", type: "success" });
-        handleSetHandlers();
-      })
-      .catch((err) => {
-        setAlert({ message: err, type: "danger" });
-        throw new Error("DELETE handler error: " + err);
-      })
-      .finally(() => {
-        setLoadingOverlay({ isLoading: false });
       });
   };
 
@@ -85,10 +56,16 @@ export default function HandlersTable({ endpointId }) {
               id="handlerHelpModal"
               body={() => <div dangerouslySetInnerHTML={{ __html: documentation }} />}
             />
-            <a className="utrecht-link" onClick={handleSetHandlers}>
+            <button
+              className="button-no-style utrecht-link"
+              disabled={getHandlers.isFetching}
+              onClick={() => {
+                queryClient.invalidateQueries("handlers");
+              }}
+            >
               <i className="fas fa-sync-alt mr-1" />
-              <span className="mr-2">Refresh</span>
-            </a>
+              <span className="mr-2">{getHandlers.isFetching ? "Fetching data..." : "Refresh"}</span>
+            </button>
             <Link to={`/endpoints/${endpointId}/handlers/new`}>
               <button className="utrecht-button utrecht-button-sm btn-sm btn-success">
                 <i className="fas fa-plus mr-2" />
@@ -102,9 +79,9 @@ export default function HandlersTable({ endpointId }) {
         return (
           <div className="row">
             <div className="col-12">
-              {showSpinner === true ? (
+              {getHandlers.isLoading ? (
                 <Spinner />
-              ) : handlers ? (
+              ) : (
                 <Table
                   columns={[
                     {
@@ -129,7 +106,7 @@ export default function HandlersTable({ endpointId }) {
                               <FontAwesomeIcon icon={faTrash} /> Delete
                             </button>
                             <DeleteModal
-                              resourceDelete={() => handleDeleteHandler({ id: item.id })}
+                              resourceDelete={() => deleteHandler.mutateAsync({ id: item.id })}
                               resourceId={item.id}
                             />
                             <Link
@@ -145,21 +122,7 @@ export default function HandlersTable({ endpointId }) {
                       },
                     },
                   ]}
-                  rows={handlers}
-                />
-              ) : (
-                <Table
-                  columns={[
-                    {
-                      headerName: "Name",
-                      field: "name",
-                    },
-                    {
-                      headerName: "Description",
-                      field: "description",
-                    },
-                  ]}
-                  rows={[]}
+                  rows={getHandlers.data ?? []}
                 />
               )}
             </div>

--- a/pwa/src/hooks/handler.ts
+++ b/pwa/src/hooks/handler.ts
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { QueryClient, useMutation, useQuery } from "react-query";
+import APIService from "../apiService/apiService";
+import APIContext from "../apiService/apiContext";
+import { AlertContext } from "../context/alertContext";
+import { LoadingOverlayContext } from "../context/loadingOverlayContext";
+import { navigate } from "gatsby-link";
+import { addItem, deleteItem, updateItem } from "../services/mutateQueries";
+
+export const useHandler = (queryClient: QueryClient) => {
+  const API: APIService = React.useContext(APIContext);
+  const [_, setAlert] = React.useContext(AlertContext);
+  const [__, setLoadingOverlay] = React.useContext(LoadingOverlayContext);
+
+  const getOne = (handlerId: string) =>
+    useQuery<any, Error>(["handlers", handlerId], () => API.Handler.getOne(handlerId), {
+      initialData: () => queryClient.getQueryData<any[]>("handlers")?.find((handler) => handler.id === handlerId),
+      onError: (error) => {
+        setAlert({ message: error.message, type: "danger" });
+      },
+      enabled: !!handlerId,
+    });
+
+  const getAllFromEndpoint = (handlerId: string) =>
+    useQuery<any[], Error>("handlers", () => API.Handler.getAllFromEndpoint(handlerId), {
+      onError: (error) => {
+        setAlert({ message: error.message, type: "danger" });
+      },
+    });
+
+  const remove = () =>
+    useMutation<any, Error, any>(API.Handler.delete, {
+      onMutate: () => {
+        setLoadingOverlay({ isLoading: true });
+      },
+      onSuccess: async (_, variables) => {
+        deleteItem(queryClient, "handlers", variables.id);
+        setAlert({ message: "Deleted handler", type: "success" });
+      },
+      onError: (error) => {
+        setAlert({ message: error.message, type: "danger" });
+      },
+      onSettled: () => {
+        setLoadingOverlay({ isLoading: false });
+      },
+    });
+
+  const createOrEdit = (endpointId: string, handlerId?: string) =>
+    useMutation<any, Error, any>(API.Handler.createOrUpdate, {
+      onMutate: () => {
+        setLoadingOverlay({ isLoading: true });
+      },
+      onSuccess: async (newHandler) => {
+        if (handlerId) {
+          updateItem(queryClient, "handlers", newHandler);
+          setAlert({ message: "Updated handler", type: "success" });
+          navigate(`/endpoints/${endpointId}/handlers`);
+        }
+
+        if (!handlerId) {
+          addItem(queryClient, "handlers", newHandler);
+          setAlert({ message: "Created handler", type: "success" });
+          navigate(`/endpoints/${endpointId}/handlers/${newHandler.id}`);
+        }
+      },
+      onError: (error) => {
+        setAlert({ message: error.message, type: "danger" });
+      },
+      onSettled: () => {
+        setLoadingOverlay({ isLoading: false });
+      },
+    });
+
+  return { getOne, getAllFromEndpoint, remove, createOrEdit };
+};


### PR DESCRIPTION
This pull request includes:

- Refactoring of `handlers` API-service to be compatible with `react-query`;
- Addition of `useHandler` hook as a wrapper for `react-query`;
- Implementation of `useHandler` in `HandlersTable` and `HandlerForm`.